### PR TITLE
Fix all instances of fileID and DataTime typo

### DIFF
--- a/R/QAQC_IRMS_functions.r
+++ b/R/QAQC_IRMS_functions.r
@@ -13,7 +13,7 @@ library(dplyr)
 #' \dontrun{
 #' # Usage example
 #' vend.list <- combineVendFileInfo(path = "./abiotic/", 
-#'                                  combColNames = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+#'                                  combColNames = c("fileID","Identifier1","Analysis","Preparation","DataTime",
 #'                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 #'                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 #'                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -1476,7 +1476,7 @@ removeRefAnalysisDXF<-function(filtered.list, refInd=7, sampInd=8,
 #' @param internalStandID.vec vector of internal standard names for calibration; default = c("L1","H1","LW")
 #' @param standAcceptedVals_vec vector of accepted delta values for internal standards; default value = c(-8.55,4.85,-3.85),
 #' @param standAcceptedSD_vec vector of acceptable sd of delta values for intenral standards; default value = c(0.2,0.2,0.2)
-#' @param useColNames vector of column names to extract vendor data from in the dxf files; default = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+#' @param useColNames vector of column names to extract vendor data from in the dxf files; default = c("fileID","Identifier1","Analysis","Preparation","DataTime",
 #'                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 #'                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 #'                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -1545,7 +1545,7 @@ QAQC_IRMS<-function(unfilteredPath,
                     standAcceptedVals_vec,
                     standAcceptedSD_vec,
                     internalStandID.vec=c("L1","H1","LW"),
-                    useColNames=c("fileId","Identifier1","Analysis","Preparation","DateTime",
+                    useColNames=c("fileID","Identifier1","Analysis","Preparation","DataTime",
                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -2449,7 +2449,7 @@ plot_pass_fail_spectra <- function(samps.dat, dataName="data", plotsPath, dxf_pa
   fileNames<-all_dxf_files(path = dxf_path)
   fileNames
   # get passed file names
-  passedFiles <- unique(samps.dat$fileId) 
+  passedFiles <- unique(samps.dat$fileID) 
   # get failed files 
   passedInd <- which(fileNames %in% passedFiles)
   failedFiles <- fileNames[-passedInd]

--- a/inst/scripts/QAQC_IRMS_functions.R.old
+++ b/inst/scripts/QAQC_IRMS_functions.R.old
@@ -9,7 +9,7 @@
 #' @examples 
 #' # Usage example
 #' vend.list <- combineVendFileInfo(path = "./abiotic/", 
-#'                                  combColNames = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+#'                                  combColNames = c("fileID","Identifier1","Analysis","Preparation","DataTime",
 #'                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 #'                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 #'                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -43,7 +43,7 @@ combineVendFileInfo<-function(path,combColNames,outputID,outPath){
     if(isVendData){
       # make a combined df
       combDF<-data.frame(cbind(df,vend[[i]][,2:ncol(vend[[i]])]))
-      # fileId, Identifier1, Analysis, DateTime, PeakNr,
+      # fileID, Identifier1, Analysis, DataTime, PeakNr,
       # Start, Rt, End, Ampl44,
       colnames(combDF)<-combColNames
       # add to list
@@ -1244,7 +1244,7 @@ removeRefAnalysisDXF<-function(filtered.list, refInd=7, sampInd=8,
 #' @param internalStandID vector of internal standard names for calibration; default = c("L1","H1","LW")
 #' @param standAcceptedVals.vec vector of accepted delta values for internal standards; default value = c(-8.55,4.85,-3.85),
 #' @param standAcceptedSD.vec vector of acceptable sd of delta values for intenral standards; default value = c(0.2,0.2,0.2)
-#' @param useColNames vector of column names to extract vendor data from in the dxf files; default = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+#' @param useColNames vector of column names to extract vendor data from in the dxf files; default = c("fileID","Identifier1","Analysis","Preparation","DataTime",
 #'                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 #'                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 #'                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -1297,7 +1297,7 @@ QAQC_IRMS<-function(unfilteredPath,
                     standAcceptedVals.vec=c(-8.55,4.85,-3.85),
                     standAcceptedSD.vec=c(0.2,0.2,0.2),
                     internalStandID=c("L1","H1","LW"),
-                    useColNames=c("fileId","Identifier1","Analysis","Preparation","DateTime",
+                    useColNames=c("fileID","Identifier1","Analysis","Preparation","DataTime",
                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -2093,7 +2093,7 @@ plot_pass_fail_spectra <- function(samps.dat, dataName="data", plotsPath, dxf_pa
   fileNames<-all_dxf_files(path = dxf_path)
   fileNames
   # get passed file names
-  passedFiles <- unique(samps.dat$fileId) 
+  passedFiles <- unique(samps.dat$fileID) 
   # get failed files 
   passedInd <- which(fileNames %in% passedFiles)
   failedFiles <- fileNames[-passedInd]

--- a/inst/scripts/QCpipeline.r
+++ b/inst/scripts/QCpipeline.r
@@ -263,7 +263,7 @@ standlm[[2]]
 
 ##### visualize pass/fail in pdfs of chromatogram thumbnails
 # Get all filenames of .dxf files in the directory
-passFiles <- unique(samps.dat$fileId)
+passFiles <- unique(samps.dat$fileID)
 
 # get passed and failed files from previously defined file names
 passedInd <- which(fileNames %in% passFiles)

--- a/inst/scripts/QCpipeline2.r
+++ b/inst/scripts/QCpipeline2.r
@@ -318,7 +318,7 @@ if (CHECK_INTERNAL_STANDARDS){
 
 ##### visualize pass/fail in pdfs of chromatogram thumbnails
 # Get all filenames of .dxf files in the directory
-passFiles <- unique(samps.dat$fileId)
+passFiles <- unique(samps.dat$fileID)
 
 if (!is.null(passFiles)){
   # get passed and failed files from previously defined file names

--- a/inst/scripts/extractDXFfeatParallel.R
+++ b/inst/scripts/extractDXFfeatParallel.R
@@ -272,13 +272,13 @@ print(paste("feature extraction: ",timeDiff,sep=""))
 #colnames(extrFeat.tab) #includes Analysis
 #final.df<-extrFeat.tab # build on tsfeatures df
 
-#colsToAdd<-c("biotic","fileId","Identifier1",    
+#colsToAdd<-c("biotic","fileID","Identifier1",    
 #             "Preparation","MgSO4","NaCl",         
 ##             "NaHCO3","Na2SO4","MgSO4_L","NaCl_U",       
 #             "NaCl_L","NaHCO3_L","NaHCO3_U","Na2SO4_L",     
 #             "Na2SO4_U","rel_MgSO4","rel_NaCl","rel_NaHCO3",   
 #             "rel_Na2SO4","saltContent","anion","cation")
-#colsToAdd<-c("fileId","Identifier1","DateTime",    
+#colsToAdd<-c("fileID","Identifier1","DataTime",    
 #  "Preparation","biotic","avg_d13C12C",
 #  "avg_d18O13C","avg_d18O16O","avg_Ampl46","avg_IntensityAll",
 #  "avg_rIntensityAll","avg_pkArea")
@@ -339,7 +339,7 @@ print(paste("feature extraction: ",timeDiff,sep=""))
 
 # organize df
 #colOrder<-c(# labels:
-#            "fileId", "DateTime","Analysis",
+#            "fileID", "DataTime","Analysis",
 #            "Identifier1",
 #            "Preparation",
 #            "biotic",

--- a/inst/scripts/new_data_feature_extraction.R
+++ b/inst/scripts/new_data_feature_extraction.R
@@ -115,10 +115,10 @@ for(i in seq(1, length(dxf_dirs.vec))){
   fullData.list<-separate_by_analysis(newdata)
   length(fullData.list)
   # colnames to not take avg and sd of
-  rm_cols <- c("fileId", "Identifier1", "Analysis", "Preparation",
-               "DateTime", "PeakNr", "Start", "Rt", "End", "ListFirstPeak",
+  rm_cols <- c("fileID", "Identifier1", "Analysis", "Preparation",
+               "DataTime", "PeakNr", "Start", "Rt", "End", "ListFirstPeak",
                "IsRef", "RefName", "Rps45CO244CO2", "Rps46CO244CO2")
-  add_back <- c("fileId", "Identifier1", "Analysis", "Preparation", "DateTime")
+  add_back <- c("fileID", "Identifier1", "Analysis", "Preparation", "DataTime")
   red_meas.list <- list()
   # loop though the dataframes in list
   for(j in seq(1,length(fullData.list))){

--- a/inst/scripts/new_merge_ms_ts.R
+++ b/inst/scripts/new_merge_ms_ts.R
@@ -49,7 +49,7 @@ dim(ms.df)
 
 
 ## find which experiment is missing in the ts list
-ms_files.26 <- ms.list[[26]]$fileId
+ms_files.26 <- ms.list[[26]]$fileID
 ms_an.26 <- ms.list[[26]]$Analysis
 length(ms_an.26)
 # [1] 35
@@ -103,7 +103,7 @@ ms_ts_data <- ms_ts_data[, sd_filter!=0]
 dim(ms_ts_data)  # [1] 853  82
 
 ######## Create the meta data
-meta_data_features <- c("Analysis", "fileId", "Identifier1", "Preparation","DateTime")
+meta_data_features <- c("Analysis", "fileID", "Identifier1", "Preparation","DataTime")
 meta_data <- ms_ts_merge_all_cols %>%
   select(one_of(meta_data_features))
 

--- a/inst/test_report.Rmd
+++ b/inst/test_report.Rmd
@@ -121,7 +121,7 @@ for(i in seq(1,length(dxf_dirs))){
     firstSampTint=20,
     outPath = WRITE_PATH,
     verbose = TRUE,
-    useColNames=c("fileId","Identifier1","Analysis","Preparation","DateTime",
+    useColNames=c("fileID","Identifier1","Analysis","Preparation","DataTime",
                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -175,7 +175,7 @@ for(i in seq(1,length(dxf_dirs))){
   }
 
  # Get all filenames of .dxf files in the directory
- passFiles <- unique(samps.dat$fileId)
+ passFiles <- unique(samps.dat$fileID)
  if(!is.null(passFiles)){
   # get passed and failed files from previously defined file names
   passedInd <- which(fileNames %in% passFiles)
@@ -312,7 +312,7 @@ for(i in seq(1,length(dxf_dirs))){
 #  firstSampTint=20,
 #  outPath = RESULT_PATH,
 #  verbose = TRUE,
-# useColNames=c("fileId","Identifier1","Analysis","Preparation","DateTime",
+# useColNames=c("fileID","Identifier1","Analysis","Preparation","DataTime",
 #                                  "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 #                                  "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 #                                  "rIntensity46","rIntensityAll","Intensity44","Intensity45",
@@ -375,7 +375,7 @@ for(i in seq(1,length(dxf_dirs))){
 # visualize pass/fail in pdfs of chromatogram thumbnails
 ```{r pass-fail-pdfs}
 # Get all filenames of .dxf files in the directory
-#passFiles <- unique(samps.dat$fileId)
+#passFiles <- unique(samps.dat$fileID)
 #if (!is.null(passFiles)){
   # get passed and failed files from previously defined file names
  # passedInd <- which(fileNames %in% passFiles)

--- a/inst/test_report2.Rmd
+++ b/inst/test_report2.Rmd
@@ -237,7 +237,7 @@ if (CHECK_INTERNAL_STANDARDS && length(currFiltered) >= 3) {
 # visualize pass/fail in pdfs of chromatogram thumbnails
 ```{r pass-fail-pdfs}
 # Get all filenames of .dxf files in the directory
-passFiles <- unique(samps.dat$fileId)
+passFiles <- unique(samps.dat$fileID)
 if (!is.null(passFiles)){
   # get passed and failed files from previously defined file names
   passedInd <- which(fileNames %in% passFiles)

--- a/man/QAQC_IRMS.Rd
+++ b/man/QAQC_IRMS.Rd
@@ -12,7 +12,7 @@ QAQC_IRMS(
   standAcceptedVals_vec,
   standAcceptedSD_vec,
   internalStandID.vec = c("L1", "H1", "LW"),
-  useColNames = c("fileId", "Identifier1", "Analysis", "Preparation", "DateTime",
+  useColNames = c("fileID", "Identifier1", "Analysis", "Preparation", "DataTime",
     "PeakNr", "Start", "Rt", "End", "Ampl44", "Ampl45", "Ampl46", "BGD44", "BGD45",
     "BGD46", "rIntensity44", "rIntensity45", "rIntensity46", "rIntensityAll",
     "Intensity44", "Intensity45", "Intensity46", "IntensityAll", "ListFirstPeak",
@@ -58,7 +58,7 @@ QAQC_IRMS(
 
 \item{internalStandID.vec}{vector of internal standard names for calibration; default = c("L1","H1","LW")}
 
-\item{useColNames}{vector of column names to extract vendor data from in the dxf files; default = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+\item{useColNames}{vector of column names to extract vendor data from in the dxf files; default = c("fileID","Identifier1","Analysis","Preparation","DataTime",
 "PeakNr","Start","Rt","End","Ampl44","Ampl45",
 "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
 "rIntensity46","rIntensityAll","Intensity44","Intensity45",

--- a/man/combineVendFileInfo.Rd
+++ b/man/combineVendFileInfo.Rd
@@ -6,7 +6,7 @@
 \usage{
 combineVendFileInfo(
   path,
-  combColNames = c("fileId", "Identifier1", "Analysis", "Preparation", "DateTime",
+  combColNames = c("fileID", "Identifier1", "Analysis", "Preparation", "DataTime",
     "PeakNr", "Start", "Rt", "End", "Ampl44", "Ampl45", "Ampl46", "BGD44", "BGD45",
     "BGD46", "rIntensity44", "rIntensity45", "rIntensity46", "rIntensityAll",
     "Intensity44", "Intensity45", "Intensity46", "IntensityAll", "ListFirstPeak",
@@ -38,7 +38,7 @@ combineVendFileInfo: function that processes vendor data for a directory of dxf 
 \dontrun{
 # Usage example
 vend.list <- combineVendFileInfo(path = "./abiotic/", 
-                                 combColNames = c("fileId","Identifier1","Analysis","Preparation","DateTime",
+                                 combColNames = c("fileID","Identifier1","Analysis","Preparation","DataTime",
                                   "PeakNr","Start","Rt","End","Ampl44","Ampl45",
                                   "Ampl46","BGD44","BGD45","BGD46","rIntensity44","rIntensity45",
                                   "rIntensity46","rIntensityAll","Intensity44","Intensity45",


### PR DESCRIPTION
Replace all instances of “fileId” with “fileID”, and “DateTime” with “DataTime.” combineVendFileInfo() and QAQC_IRMS() now expect the correct dataframe columns from files. 
